### PR TITLE
Add `MYSQL_CA_CERT` for MySQL SSL connection 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## UNRELEASED
+* Allow connecting to MySQL through SSL by providing a CA certificate
+
 ## v0.40.0
 Update version number
 

--- a/README.md
+++ b/README.md
@@ -106,3 +106,7 @@ Example for creating a thumbnail resize and crop:
 http://imageserver.com/image/path.png/:/rs=w:350,h:250;cp=w:350,h:250
 ```
 For all options (resizing, cropping, filter, etc) check [node-steam](https://github.com/asilvas/node-image-steam).
+
+## MySQL with SSL
+
+When you want to connect to a MySQL server using SSL, a Certificate Authority certificate is required. The contents of this CA certificate can be passed into the `MYSQL_CA_CERT` environment variable.

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,17 +1,25 @@
 // Update with your config settings.
 require('dotenv').config();
 
+const connection = {
+  host:     process.env.DB_HOST,
+  database: process.env.DB_NAME,
+  user:     process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+};
+
+if (process.env.MYSQL_CA_CERT) {
+	connection.ssl = {
+		rejectUnauthorized: true,
+		ca: [ process.env.MYSQL_CA_CERT ]
+	}
+}
+
 module.exports = {
 
   development: {
     client: 'mysql',
-    connection: {
-      host:     process.env.DB_HOST || 'localhost',
-      database: process.env.DB_NAME,
-      user:     process.env.DB_USER,
-      password: process.env.DB_PASSWORD,
-      port: process.env.DB_PORT || '3306',
-    },
+    connection,
     migrations: {
       directory: __dirname + '/knex/migrations',
     },
@@ -22,13 +30,7 @@ module.exports = {
 
   production: {
     client: 'mysql',
-    connection: {
-      host:     process.env.DB_HOST || 'localhost',
-      database: process.env.DB_NAME,
-      user:     process.env.DB_USER,
-      password: process.env.DB_PASSWORD,
-      port: process.env.DB_PORT || '3306',
-    },
+    connection,
     migrations: {
       directory: __dirname + '/knex/migrations',
     },


### PR DESCRIPTION
<!-- Please fill in the appropriate information -->

# Description

Currently it's not possible to connect to a MySQL server through SSL. This PR adds a `MYSQL_CA_CERT` environment variable which allows us to add a CA (Certificate Authority) certificate. When this certificate is provided, it is added to the MySQL connection options, and invalid SSL handshakes / certificates are rejected.

Related PRs have been made in the auth, api & kubernetes repositories: 

https://github.com/openstad/openstad-oauth2-server/pull/113
https://github.com/openstad/openstad-api/pull/241
https://github.com/openstad/openstad-kubernetes/pull/78

## Issue reference



## Type of change

New feature through an environment variable. Keeps backwards compatibility.

## Documentation

See README.md

## Tests

Locally

## Branch



