### PR TITLE
feat: disable metadata in imagesteps

### DIFF
--- a/server.js
+++ b/server.js
@@ -48,6 +48,18 @@ const imageSteamConfig = {
   log: {
     errors: true,
   },
+  router: {
+    originalSteps: {
+      metadata: {
+        enabled: 'false',
+      },
+    },
+    hqOriginalSteps: {
+      metadata: {
+        enabled: 'false',
+      },
+    },
+  },
 };
 
 if (process.env.S3_ENDPOINT) {


### PR DESCRIPTION
# Description

Exif metadata is still available in images (like GPS coordinates, phone type used etc.). This should remove exif data when an image is resized.

## Issue reference

Vulnerability reported

## Type of change

Vulnerability fix
